### PR TITLE
Add accessible labels to contact form fields

### DIFF
--- a/src/DhrupadPentesterPortfolio.tsx
+++ b/src/DhrupadPentesterPortfolio.tsx
@@ -32,7 +32,9 @@ const Chip = ({ children }: any) => (
 );
 
 const Card = ({ children, className = "" }: any) => (
-  <div className={\`group relative rounded-2xl border border-white/10 bg-gradient-to-b from-white/5 to-white/[0.03] p-5 sm:p-6 shadow-2xl shadow-black/30 hover:shadow-cyan-500/10 hover:border-cyan-400/30 transition \${className}\`}>
+  <div
+    className={`group relative rounded-2xl border border-white/10 bg-gradient-to-b from-white/5 to-white/[0.03] p-5 sm:p-6 shadow-2xl shadow-black/30 hover:shadow-cyan-500/10 hover:border-cyan-400/30 transition ${className}`}
+  >
     <div className="absolute inset-0 rounded-2xl opacity-0 group-hover:opacity-100 transition bg-[radial-gradient(60%_60%_at_50%_0%,rgba(0,255,255,0.08),transparent_70%)]" />
     {children}
   </div>
@@ -434,11 +436,46 @@ $ echo "Offense informs defense."`}
         <Card>
           <form className="grid gap-4">
             <div className="grid sm:grid-cols-2 gap-4">
-              <input placeholder="Name" className="rounded-xl bg-white/5 border border-white/10 px-4 py-2 outline-none focus:border-cyan-400/50" />
-              <input placeholder="Email" className="rounded-xl bg-white/5 border border-white/10 px-4 py-2 outline-none focus:border-cyan-400/50" />
+              <div className="flex flex-col">
+                <label htmlFor="name" className="sr-only">
+                  Name
+                </label>
+                <input
+                  id="name"
+                  name="name"
+                  placeholder="Name"
+                  className="rounded-xl bg-white/5 border border-white/10 px-4 py-2 outline-none focus:border-cyan-400/50"
+                />
+              </div>
+              <div className="flex flex-col">
+                <label htmlFor="email" className="sr-only">
+                  Email
+                </label>
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  placeholder="Email"
+                  className="rounded-xl bg-white/5 border border-white/10 px-4 py-2 outline-none focus:border-cyan-400/50"
+                />
+              </div>
             </div>
-            <textarea placeholder="Your message" rows={4} className="rounded-xl bg-white/5 border border-white/10 px-4 py-2 outline-none focus:border-cyan-400/50" />
-            <button type="button" className="justify-self-start rounded-xl px-4 py-2 bg-gradient-to-r from-cyan-500/70 to-fuchsia-500/70 hover:from-cyan-500 hover:to-fuchsia-500 border border-white/10 shadow-lg">
+            <div className="flex flex-col">
+              <label htmlFor="message" className="sr-only">
+                Your message
+              </label>
+              <textarea
+                id="message"
+                name="message"
+                placeholder="Your message"
+                rows={4}
+                className="rounded-xl bg-white/5 border border-white/10 px-4 py-2 outline-none focus:border-cyan-400/50"
+              />
+            </div>
+            <button
+              type="button"
+              className="justify-self-start rounded-xl px-4 py-2 bg-gradient-to-r from-cyan-500/70 to-fuchsia-500/70 hover:from-cyan-500 hover:to-fuchsia-500 border border-white/10 shadow-lg"
+            >
               Send (disabled in demo)
             </button>
           </form>


### PR DESCRIPTION
## Summary
- ensure contact form fields have associated labels with `id`/`name` attributes
- fix `Card` component template string to avoid build error

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcf1494c94832facc32046aa03ee87