### PR TITLE
refactor: add interfaces for portfolio components

### DIFF
--- a/src/DhrupadPentesterPortfolio.tsx
+++ b/src/DhrupadPentesterPortfolio.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, ReactNode } from "react";
 import { motion } from "framer-motion";
 
 import profilePic from "./1743031208247.jpeg";
@@ -8,7 +8,23 @@ import postGenAiImg from "./1745196946372.jpeg";
 import postCapImg from "./1745196947867.jpeg";
 import postMaccdcImg from "./1737680879943.jpeg";
 
-const Section = ({ id, title, subtitle, children }: any) => (
+interface SectionProps {
+  id: string;
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+}
+
+interface ChipProps {
+  children: ReactNode;
+}
+
+interface CardProps {
+  children: ReactNode;
+  className?: string;
+}
+
+const Section = ({ id, title, subtitle, children }: SectionProps) => (
   <section id={id} className="scroll-mt-24 py-16 sm:py-24">
     <div className="max-w-6xl mx-auto px-4">
       <div className="mb-8">
@@ -25,14 +41,14 @@ const Section = ({ id, title, subtitle, children }: any) => (
   </section>
 );
 
-const Chip = ({ children }: any) => (
+const Chip = ({ children }: ChipProps) => (
   <span className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs sm:text-sm text-white/80 backdrop-blur hover:bg-white/10 transition">
     {children}
   </span>
 );
 
-const Card = ({ children, className = "" }: any) => (
-  <div className={\`group relative rounded-2xl border border-white/10 bg-gradient-to-b from-white/5 to-white/[0.03] p-5 sm:p-6 shadow-2xl shadow-black/30 hover:shadow-cyan-500/10 hover:border-cyan-400/30 transition \${className}\`}>
+const Card = ({ children, className = "" }: CardProps) => (
+  <div className={`group relative rounded-2xl border border-white/10 bg-gradient-to-b from-white/5 to-white/[0.03] p-5 sm:p-6 shadow-2xl shadow-black/30 hover:shadow-cyan-500/10 hover:border-cyan-400/30 transition ${className}`}>
     <div className="absolute inset-0 rounded-2xl opacity-0 group-hover:opacity-100 transition bg-[radial-gradient(60%_60%_at_50%_0%,rgba(0,255,255,0.08),transparent_70%)]" />
     {children}
   </div>


### PR DESCRIPTION
## Summary
- define `SectionProps`, `ChipProps`, and `CardProps`
- type `Section`, `Chip`, and `Card` components using new interfaces

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcf14490b8832fb1e665e5ffc8dc4e