### PR TITLE
fix: simplify Card className template

### DIFF
--- a/src/DhrupadPentesterPortfolio.tsx
+++ b/src/DhrupadPentesterPortfolio.tsx
@@ -32,7 +32,7 @@ const Chip = ({ children }: any) => (
 );
 
 const Card = ({ children, className = "" }: any) => (
-  <div className={\`group relative rounded-2xl border border-white/10 bg-gradient-to-b from-white/5 to-white/[0.03] p-5 sm:p-6 shadow-2xl shadow-black/30 hover:shadow-cyan-500/10 hover:border-cyan-400/30 transition \${className}\`}>
+  <div className={`group relative rounded-2xl border border-white/10 bg-gradient-to-b from-white/5 to-white/[0.03] p-5 sm:p-6 shadow-2xl shadow-black/30 hover:shadow-cyan-500/10 hover:border-cyan-400/30 transition ${className}`}>
     <div className="absolute inset-0 rounded-2xl opacity-0 group-hover:opacity-100 transition bg-[radial-gradient(60%_60%_at_50%_0%,rgba(0,255,255,0.08),transparent_70%)]" />
     {children}
   </div>


### PR DESCRIPTION
## Summary
- use standard template literal for Card className

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcf143a1c0832f97c995f889c71ea9